### PR TITLE
Better README, Cross-Platform Config Path, Custom Config Dir Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # lazyfivem
-A simple CUI for running any FiveM server and executing commands.
+A simple TUI for running any FiveM server and executing commands.
 
-## Install
+## Installation
 
-### Windows (scoop)
+### Windows
+- via Scoop (Recommended)
 ```
 # Add the extras bucket
 scoop bucket add itschip https://github.com/itschip/scoop-bucket.git
@@ -13,36 +14,76 @@ scoop install itschip/lazyfivem
 ```
 
 ### Linux
-```
+```bash
 curl -Lo lazyfivem.tar.gz https://github.com/itschip/lazyfivem/releases/download/1.0.2/lazyfivem_1.0.2_Linux_32-bit.tar.gz
-```
-```
+
 sudo tar xf lazyfivem.tar.gz -C /usr/local/bin lazyfivem
 ```
 
-### Adding servers
+### Via GitHub Releases
+Go to [the latest release page](https://github.com/itschip/lazyfivem/releases/latest) and download the corresponding version for your OS.
+
+## Configuration
 Create a `config.yaml` to:
-- Linux: ~/.lazyfivem/
-- Windows: $HOME:
-Create a folder called `.lazyfivem` and a file inside called `config.yaml`.
+- Linux: `~/.config/lazyfivem/`
+- Windows: `C:\Users\USERNAME\AppData\Roaming\lazyfivem\` aka. `%APPDATA%\lazyfivem\`
+
 Example:
+- Windows:
+  ```pwsh
+  mkdir $APPDATA\lazyfivem
+  
+  # Then create config.yaml inside
+  ```
+- Linux:
+  ```bash
+  mkdir ~/.config/lazyfivem
+  
+  cd ~/.config/lazyfivem
+  
+  touch config.yaml
+  ```
+
+### Custom Config Directory
+
+You can change the config directory by exporting the `LAZYFIVEM_CONFIG_HOME` environment variable. You can then place the `config.yaml` file there.
+
+### Adding Servers
+
+Create a new entry in the `config.yaml` file as follows:
+
+`Server Name: '<command to start the server>'`
+
+#### Windows:
+
+```yaml
+Server Name: 'PATH\TO\SERVER\start.bat'
 ```
-mkdir $HOME/.lazyfivem
-# Then create config.yaml inside
+
+Example:
+```yaml
+Yet Another RP Server: 'D:\FxServer\start.bat'
 ```
 
-You can then add servers to `config.yaml` like this (example)
-```yml
-Windows Server: "X:/ServerFX/starter.bat"
-Linux Server: "cd ~/FXServer/server-data && ~/FXServer/server/run.sh +exec server.cfg"
+#### Linux:
+
+```yaml
+Server Name: 'PATH/TO/SERVER/start.sh'
 ```
 
-Then, just run `lazyfivem` in any terminal.
+Example:
+```yaml
+Yet Another RP Server: 'PATH/TO/SERVER/start.sh'
+```
 
+## Usage
+Run `lazyfivem` in any terminal.
 
-## Mappings
-* **TAB** - Moves cursor between the sidebar and command exec view
-* **ENTER** - Starts the selected when you're in the sidebar view, and executes the command when you're in the command exec view.
+### Navigation
+* **TAB** - Switches focus between the sidebar and command line
+* **ENTER** - Starts the selected server in the sidebar, and executes a command in the command line.
+* **UP/DOWN ARROW** - Scrolls up/down in the sidebar
+* **LEFT/RIGHT ARROW** - Moves cursor left/right in the command exec lin
 
 ### Example of Prisma in FiveM failing.
 ![vmplayer_lqEQwqQhEj](https://user-images.githubusercontent.com/59088889/190914038-df755ce0-7485-4c7b-95fb-7af33a2cb686.png)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ sudo tar xf lazyfivem.tar.gz -C /usr/local/bin lazyfivem
 ```
 
 ### Adding servers
-Create a folder called `.lazyfivem` and a file inside called `config.yaml` at the very root of your computer.
+Create a `config.yaml` to:
+- Linux: ~/.lazyfivem/
+- Windows: $HOME:
+Create a folder called `.lazyfivem` and a file inside called `config.yaml`.
 Example:
 ```
 mkdir $HOME/.lazyfivem

--- a/README.md
+++ b/README.md
@@ -25,8 +25,18 @@ Go to [the latest release page](https://github.com/itschip/lazyfivem/releases/la
 
 ## Configuration
 Create a `config.yaml` to:
-- Linux: `~/.config/lazyfivem/`
+
+- Unix-based OS:
+    - if `$XDG_CONFIG_HOME` is specified, then: `$XDG_CONFIG_HOME/lazyfivem/`
+    - otherwise `$HOME/.config/lazyfivem/`
+
+- Darwin: `$HOME/Library/Application Support/lazyfivem/`
+
+- Plan 9: `$home/lib`
+
 - Windows: `C:\Users\USERNAME\AppData\Roaming\lazyfivem\` aka. `%APPDATA%\lazyfivem\`
+
+- [Read more](https://pkg.go.dev/os#UserConfigDir)
 
 Example:
 - Windows:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Run `lazyfivem` in any terminal.
 * **ENTER** - Starts the selected server in the sidebar, and executes a command in the command line.
 * **UP/DOWN ARROW** - Scrolls up/down in the sidebar
 * **LEFT/RIGHT ARROW** - Moves cursor left/right in the command exec lin
+* **Ctrl-C** - Quit program
 
 ### Example of Prisma in FiveM failing.
 ![vmplayer_lqEQwqQhEj](https://user-images.githubusercontent.com/59088889/190914038-df755ce0-7485-4c7b-95fb-7af33a2cb686.png)

--- a/files.go
+++ b/files.go
@@ -2,27 +2,21 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os/user"
+	"os"
 	"strings"
 
 	"github.com/spf13/viper"
 )
 
 func getConfigValues() {
-	usr, err := user.Current()
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	home_dir := usr.HomeDir
-
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
-	// Win
-	viper.AddConfigPath(home_dir + "/.lazyfivem/")
-	// viper.AddConfigPath(os.ExpandEnv("~/.lazyfivem/"))
+
+	user_config_dir, err := os.UserConfigDir()
+
+	// Should work on any OS
+	viper.AddConfigPath(os.ExpandEnv("$LAZYFIVEM_CONFIG_HOME"))
+	viper.AddConfigPath(user_config_dir + "/.lazyfivem/")
 
 	err = viper.ReadInConfig()
 

--- a/files.go
+++ b/files.go
@@ -2,19 +2,30 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os/user"
 	"strings"
 
 	"github.com/spf13/viper"
 )
 
 func getConfigValues() {
+	usr, err := user.Current()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	home_dir := usr.HomeDir
+
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 	// Win
-	viper.AddConfigPath("$HOME/.lazyfivem/")
-	viper.AddConfigPath("~/.lazyfivem/")
+	viper.AddConfigPath(home_dir + "/.lazyfivem/")
+	// viper.AddConfigPath(os.ExpandEnv("~/.lazyfivem/"))
 
-	err := viper.ReadInConfig()
+	err = viper.ReadInConfig()
+
 	if err != nil {
 		panic(fmt.Errorf("Failed to load lazyfivem config: %w", err))
 	}

--- a/files.go
+++ b/files.go
@@ -12,13 +12,13 @@ func getConfigValues() {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 
-	user_config_dir, err := os.UserConfigDir()
+	user_config_dir, _ := os.UserConfigDir()
 
 	// Should work on any OS
 	viper.AddConfigPath(os.ExpandEnv("$LAZYFIVEM_CONFIG_HOME"))
-	viper.AddConfigPath(user_config_dir + "/.lazyfivem/")
+	viper.AddConfigPath(user_config_dir + "/lazyfivem/")
 
-	err = viper.ReadInConfig()
+	err := viper.ReadInConfig()
 
 	if err != nil {
 		panic(fmt.Errorf("Failed to load lazyfivem config: %w", err))

--- a/keybinds.go
+++ b/keybinds.go
@@ -5,6 +5,7 @@ import (
 )
 
 func keybinds(g *gocui.Gui) error {
+	// Quit
 	if err := g.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Clarified a few things in the README.

- Fixed the config path and made it cross-platform (the `$HOME` environment variable was blank because it's a user-wide variable and the code retrieved a system-wide variable, which doesn't exist)

- Changed the default config directory path from `$HOME/.lazyfivem` to `%APPDATA%\lazyfivem` on Windows and `$XDG_CONFIG_HOME/lazyfivem` on Unix. [Read more](https://pkg.go.dev/os#UserConfigDir)

- Added the ability to set a custom config directory path via `LAZYFIVEM_CONFIG_HOME`